### PR TITLE
ref(context): add log disposer into logging context

### DIFF
--- a/aijson/program.py
+++ b/aijson/program.py
@@ -2,8 +2,36 @@ import contextlib
 from aijson.decorate import aijson
 
 
+class JsonDisposer:
+    def __init__(self, path):
+        self.path = path
+
+    def dump(self, data):
+        with open(self.path, "w") as f:
+            json.dump(data, f)
+
+
+def formatter_factory(format="json", path=None):
+    if format == "json":
+        return JsonDisposer(path=path)
+    else:
+        raise NotImplementedError(f"{format} not supported yet!")
+
+
+class LogDisposer:
+    def __init__(self, data=None):
+        self.data = data
+
+    def dump(path=".model.ai.json", format="json"):
+        formatter = formatter_factory(format=format, path=path)
+        formatter.dump(self.data)
+
+    def __str__(self):
+        return json.dumps(self.data)
+
+
 @contextlib.contextmanager
 def logging_context():
     aijson.reset()
-    yield aijson.graph
+    yield LogDisposer(data=aijson.graph)
     aijson.reset()

--- a/aijson/program.py
+++ b/aijson/program.py
@@ -19,19 +19,23 @@ def formatter_factory(format="json", path=None):
 
 
 class LogDisposer:
-    def __init__(self, data=None):
-        self.data = data
+    def __init__(self, graph=None):
+        self._graph = graph
+
+    @property
+    def graph(self):
+        return self._graph 
 
     def dump(path=".model.ai.json", format="json"):
         formatter = formatter_factory(format=format, path=path)
-        formatter.dump(self.data)
+        formatter.dump(self.graph)
 
     def __str__(self):
-        return json.dumps(self.data)
+        return json.dumps(self.graph)
 
 
 @contextlib.contextmanager
 def logging_context():
     aijson.reset()
-    yield LogDisposer(data=aijson.graph)
+    yield LogDisposer(graph=aijson.graph)
     aijson.reset()


### PR DESCRIPTION
Because why not!

```python
import json
from example.themod import MyPyTorchModel, MyCompose
from aijson import aijson, logging_context
from torch.nn import GRU

with logging_context() as lc:
    m = MyPyTorchModel(n_layers=1, n_hidden=512, n_input=64)
    rnn = aijson(GRU)(
        input_size=2,
        hidden_size=5,
    )
    n = MyCompose(functions=[m, m, 2, rnn])

   lc.dump("ai.model.json")
   
   # access graph
   print(lc.graph)
   # or
   print(lc)
```



CAUTION:
NOT TESTED!!